### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Homemade-Cookies/ca054b9a-1318-4728-b72f-b3d45353d9df/016f9fcc-b87f-49d0-b6b2-6d4410d1d6fd/_apis/work/boardbadge/efe04da1-c69e-4901-97b2-558c11bab349)](https://dev.azure.com/Homemade-Cookies/ca054b9a-1318-4728-b72f-b3d45353d9df/_boards/board/t/016f9fcc-b87f-49d0-b6b2-6d4410d1d6fd/Microsoft.RequirementCategory)
 # MinimalAPI
 Minimal API with Authentication
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Homemade-Cookies/ca054b9a-1318-4728-b72f-b3d45353d9df/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.